### PR TITLE
adding <limits> to make C++11 and C++17 compilers work

### DIFF
--- a/include/OpenFrames/PolyhedralCone.hpp
+++ b/include/OpenFrames/PolyhedralCone.hpp
@@ -21,6 +21,7 @@
 #ifndef _OF_POLYHEDRALCONE_
 #define _OF_POLYHEDRALCONE_
 
+#include <limits>
 #include <OpenFrames/Export.h>
 #include <OpenFrames/ReferenceFrame.hpp>
 #include <osg/PositionAttitudeTransform>

--- a/include/OpenFrames/PolyhedralCone.hpp
+++ b/include/OpenFrames/PolyhedralCone.hpp
@@ -21,10 +21,10 @@
 #ifndef _OF_POLYHEDRALCONE_
 #define _OF_POLYHEDRALCONE_
 
-#include <limits>
 #include <OpenFrames/Export.h>
 #include <OpenFrames/ReferenceFrame.hpp>
 #include <osg/PositionAttitudeTransform>
+#include <limits>
 
 namespace OpenFrames
 {

--- a/src/EllipticCone.cpp
+++ b/src/EllipticCone.cpp
@@ -18,8 +18,8 @@
  * EllipticCone class function definitions.
  */
 
-#include <limits>
 #include <OpenFrames/EllipticCone.hpp>
+#include <limits>
 
 namespace OpenFrames
 {

--- a/src/EllipticCone.cpp
+++ b/src/EllipticCone.cpp
@@ -18,6 +18,7 @@
  * EllipticCone class function definitions.
  */
 
+#include <limits>
 #include <OpenFrames/EllipticCone.hpp>
 
 namespace OpenFrames

--- a/src/PolyhedralCone.cpp
+++ b/src/PolyhedralCone.cpp
@@ -17,7 +17,6 @@
 /** \file PolyhedralCone.cpp
  * PolyhedralCone class function definitions.
  */
-#include <limits>
 
 #include <OpenFrames/PolyhedralCone.hpp>
 #include <osg/BlendFunc>
@@ -25,6 +24,7 @@
 #include <osg/Geometry>
 #include <osg/PolygonOffset>
 #include <osg/PositionAttitudeTransform>
+#include <limits>
 
 namespace OpenFrames
 {

--- a/src/PolyhedralCone.cpp
+++ b/src/PolyhedralCone.cpp
@@ -17,6 +17,7 @@
 /** \file PolyhedralCone.cpp
  * PolyhedralCone class function definitions.
  */
+#include <limits>
 
 #include <OpenFrames/PolyhedralCone.hpp>
 #include <osg/BlendFunc>

--- a/src/RectangularCone.cpp
+++ b/src/RectangularCone.cpp
@@ -17,8 +17,9 @@
 /** \file RectangularCone.cpp
  * RectangularCone class function definitions.
  */
-#include <limits>
+
 #include <OpenFrames/RectangularCone.hpp>
+#include <limits>
 
 namespace OpenFrames
 {

--- a/src/RectangularCone.cpp
+++ b/src/RectangularCone.cpp
@@ -17,7 +17,7 @@
 /** \file RectangularCone.cpp
  * RectangularCone class function definitions.
  */
-
+#include <limits>
 #include <OpenFrames/RectangularCone.hpp>
 
 namespace OpenFrames

--- a/src/SensorVisibilityCallback.cpp
+++ b/src/SensorVisibilityCallback.cpp
@@ -2,10 +2,9 @@
  * Definitions for the SensorVisibilityCallback class
  */
 
-#include <limits>
-
 #include <OpenFrames/SensorVisibilityCallback.hpp>
 #include <iostream>
+#include <limits>
 
 namespace OpenFrames
 {

--- a/src/SensorVisibilityCallback.cpp
+++ b/src/SensorVisibilityCallback.cpp
@@ -2,6 +2,8 @@
  * Definitions for the SensorVisibilityCallback class
  */
 
+#include <limits>
+
 #include <OpenFrames/SensorVisibilityCallback.hpp>
 #include <iostream>
 


### PR DESCRIPTION
Fix for Ubuntu 22.04 on WSL2 Windows 10 Pro.

These additions should be redundant for all other variants of Ubuntu, but for some reason are needed to avoid compiler errors within a WSL2 environment.

Similar fixes may need to be added for other OpenFrames modules (Python, Fortran etc)

Correction : errors are persistent on Ubuntu 22.04 desktop version as well, including VM version via VirtualBox.