### PR TITLE
use qtpy Qt interface layer instead of hardcoded PyQt5

### DIFF
--- a/Demos/Python/ofqt_demo.py
+++ b/Demos/Python/ofqt_demo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Launches a demonstration of OpenFrames managed within a PyQt5 framework
+Launches a demonstration of OpenFrames managed within a qtpy framework
 
 Copyright (c) 2021 Emergent Space Technologies, Inc.
 """
@@ -26,20 +26,20 @@ else: # OSX/Linux
         os.environ['OSG_FILE_PATH'] = str(os.environ.get('OSG_FILE_PATH')) + os.pathsep + "/System/Library/Fonts/Supplemental"
 
 # Import modules
-from PyQt5.QtWidgets import *
-from PyQt5.QtGui import QSurfaceFormat
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import *
+from qtpy.QtGui import QSurfaceFormat
+from qtpy.QtCore import Qt
 import OFInterfaces.PyQtOF as PyQtOF
 import OFInterfaces.PyOF as PyOF
 
-from PyQt5.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+from qtpy.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
     QMetaObject, QObject, QPoint, QRect,
     QSize, QTime, QUrl, Qt)
-from PyQt5.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+from qtpy.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PyQt5.QtWidgets import (QApplication, QDockWidget, QMainWindow, QMenuBar,
+from qtpy.QtWidgets import (QApplication, QDockWidget, QMainWindow, QMenuBar,
     QSizePolicy, QStatusBar, QWidget)
 
 class Ui_MainWindow(object):
@@ -168,7 +168,7 @@ class TabWindow(QWidget):
         label = QLabel("Widget in a Tab.")
 
         self.ofwidget = PyQtOF.OFWidget(MyOFDemoWin1)
-        self.ofwidget.setWindowTitle('PyQt5 OpenFrames Window 1')
+        self.ofwidget.setWindowTitle('qtpy OpenFrames Window 1')
         self.ofwidget.setGeometry(50, 50, 1024, 768)
 
         tabwidget = QTabWidget()
@@ -205,7 +205,7 @@ if __name__ == '__main__':
     
     # Create standalone window
     #exStandaloneWindow = PyQtOF.OFWidget(MyOFDemoWin2)
-    #exStandaloneWindow.setWindowTitle('PyQt5 OpenFrames Window 2')
+    #exStandaloneWindow.setWindowTitle('qtpy OpenFrames Window 2')
     #exStandaloneWindow.setGeometry(100, 100, 1024, 768)
     #exStandaloneWindow.show()
     

--- a/Demos/Python/ofqt_interfacec_demo.py
+++ b/Demos/Python/ofqt_interfacec_demo.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-Launches a demonstration of OpenFrames managed within a PyQt5 framework
+Launches a demonstration of OpenFrames managed within a qtpy framework
 
 """
 
 import sys
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtGui import QSurfaceFormat
+from qtpy.QtWidgets import QApplication
+from qtpy.QtGui import QSurfaceFormat
 import OFInterfaces.PyQtOFInterfaceC as PyQtOF
 from OFInterfaces.PyOFInterfaceC import *
 
@@ -75,13 +75,13 @@ if __name__ == '__main__':
     
     # Create first window
     ex1 = PyQtOF.Widget(MyOFDemoWin1)
-    ex1.setWindowTitle('PyQt5 OpenFrames Window 1')
+    ex1.setWindowTitle('qtpy OpenFrames Window 1')
     ex1.setGeometry(50, 50, 1024, 768)
     ex1.show()
     
     # Create second window
     ex2 = PyQtOF.Widget(MyOFDemoWin2)
-    ex2.setWindowTitle('PyQt5 OpenFrames Window 2')
+    ex2.setWindowTitle('qtpy OpenFrames Window 2')
     ex2.setGeometry(100, 100, 1024, 768)
     ex2.show()
     

--- a/OFInterfaces/PyQtOF.py
+++ b/OFInterfaces/PyQtOF.py
@@ -5,9 +5,9 @@ Qt Widgets to integrate OpenFrames
 """
 
 from sys import platform
-from PyQt5.QtWidgets import QWidget, QDockWidget, QGridLayout, QSizePolicy, QLabel
-from PyQt5.QtGui import QWindow, QOpenGLContext
-from PyQt5.QtCore import Qt, QSize, QCoreApplication, QEventLoop
+from qtpy.QtWidgets import QWidget, QDockWidget, QGridLayout, QSizePolicy, QLabel
+from qtpy.QtGui import QWindow, QOpenGLContext
+from qtpy.QtCore import Qt, QSize, QCoreApplication, QEventLoop
 from . import PyOF
 
 DEFAULT_WIDTH = 320
@@ -191,7 +191,7 @@ class OFWindow(QWindow):
 
         Parameters
         ----------
-        event : PyQt5.QtGui.QKeyEvent.QKeyEvent
+        event : qtpy.QtGui.QKeyEvent.QKeyEvent
             The key event to map
 
         Returns

--- a/OFInterfaces/PyQtOFInterfaceC.py
+++ b/OFInterfaces/PyQtOFInterfaceC.py
@@ -4,9 +4,9 @@ Qt Widgets for implementing OpenFrames
 
 """
 
-from PyQt5.QtWidgets import QWidget, QGridLayout, QSizePolicy
-from PyQt5.QtGui import QWindow, QOpenGLContext
-from PyQt5.QtCore import Qt, QSize, QCoreApplication, QEventLoop
+from qtpy.QtWidgets import QWidget, QGridLayout, QSizePolicy
+from qtpy.QtGui import QWindow, QOpenGLContext
+from qtpy.QtCore import Qt, QSize, QCoreApplication, QEventLoop
 from .PyOFInterfaceC import *
 
 
@@ -204,7 +204,7 @@ class Window(QWindow):
 
         Parameters
         ----------
-        event : PyQt5.QtGui.QKeyEvent.QKeyEvent
+        event : qtpy.QtGui.QKeyEvent.QKeyEvent
             The key event to map
 
         Returns


### PR DESCRIPTION
Modern convention is to use the `qtpy` layer: https://github.com/spyder-ide/qtpy

Then the user installs whatever Python/Qt interface they want to use (PyQt5, PyQt6, PySide2, PySide6, etc.)